### PR TITLE
Migrate to Docker Compose V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These steps will install required dependencies, pull all the Docker images from 
  
 #### 1. Install pre-requisite programs:
 
-Convienent script to install git, python3-pip, docker-compose, and docker.
+Convenient script to install git, docker compose, and docker.
 
 ```
 sudo bash -c "$(curl -sS https://raw.githubusercontent.com/flightaware/fa-grafana/master/install.sh)"
@@ -57,7 +57,7 @@ HOST_IP=<set IP address>
 #### 5. Start up containers
 
 ```
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 #### 6. Open Grafana in a web browser by entering your Pi's local IP address and the configured Grafana port number
@@ -78,7 +78,7 @@ sudo docker-compose up -d
 #### 1. Stop fa-grafana docker containers
 ```
 cd fa-grafana
-sudo docker-compose down
+sudo docker compose down
 ```
 #### 2. Pull latest source code
 ```
@@ -92,7 +92,7 @@ sudo docker volume rm fa-grafana_grafana_data
 ```
 #### 5. Start up containers
 ```
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
   
 
@@ -145,7 +145,7 @@ GRAFANA_THEME=dark
   
 #### To stop all Docker containers, cd into the fa-grafana directory and use the following command:
 ```
-sudo docker-compose down
+sudo docker compose down
 ```
 #### List all running Docker containers
 ```

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 echo "Installing required programs to set up fa-grafana..."
 
 # install required packages
-requirements=("git pip3 docker docker-compose")
+requirements=("git docker")
 
 apt-get update
 
@@ -19,13 +19,8 @@ do
 		git)
 			apt-get install -y $program
 		;;
-		pip3)
-			apt-get install -y python3-pip
-		;;
-		docker-compose)
-			pip3 install docker-compose > /dev/null
-		;;
 		docker)
+			# Install Docker and Docker Compose
 			curl -sSL https://get.docker.com | sh > /dev/null
 			echo "Adding pi user to docker group..."
 			usermod -aG docker pi


### PR DESCRIPTION
Update installation script and documentation to reflect the changes between Docker Compose V1 and V2 ([Migrate to Compose V2](https://docs.docker.com/compose/migrate/)).